### PR TITLE
Spectral/masses

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,12 +13,13 @@ CookBooks = "7bce7c31-0f61-4fd7-bdaf-6b04abfa2cc7"
 ManagedLoops = "36a4119d-6b73-4371-88fe-ba2d91f5495d"
 MutatingOrNot = "6a37069a-9a67-4b2d-a34a-f09ab4b23c7c"
 PackageExtensionCompat = "65ce6f38-6b18-4e1d-a461-8949797d7930"
-
-[weakdeps]
 SHTnsSpheres = "9e5c175a-5132-4517-85a1-2957ec255f89"
 
+[weakdeps]
+# SHTnsSpheres = "9e5c175a-5132-4517-85a1-2957ec255f89"
+
 [extensions]
-SHTnsSpheres_Ext = ["SHTnsSpheres"]
+# SHTnsSpheres_Ext = ["SHTnsSpheres"]
 
 [compat]
 CFDomains = "0.1.6, 0.2"

--- a/Project.toml
+++ b/Project.toml
@@ -33,6 +33,7 @@ julia = "1.8"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+SHTnsSpheres = "9e5c175a-5132-4517-85a1-2957ec255f89"
 
 [targets]
 test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CFHydrostatics"
 uuid = "0dc8c93d-0116-402a-b00b-85ddfe5501a2"
 authors = ["The ClimFlows contributors"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 CFDomains = "3699aaca-035b-4155-96ec-eecb526248de"
@@ -13,13 +13,13 @@ CookBooks = "7bce7c31-0f61-4fd7-bdaf-6b04abfa2cc7"
 ManagedLoops = "36a4119d-6b73-4371-88fe-ba2d91f5495d"
 MutatingOrNot = "6a37069a-9a67-4b2d-a34a-f09ab4b23c7c"
 PackageExtensionCompat = "65ce6f38-6b18-4e1d-a461-8949797d7930"
-SHTnsSpheres = "9e5c175a-5132-4517-85a1-2957ec255f89"
-
-[weakdeps]
 # SHTnsSpheres = "9e5c175a-5132-4517-85a1-2957ec255f89"
 
+[weakdeps]
+SHTnsSpheres = "9e5c175a-5132-4517-85a1-2957ec255f89"
+
 [extensions]
-# SHTnsSpheres_Ext = ["SHTnsSpheres"]
+SHTnsSpheres_Ext = ["SHTnsSpheres"]
 
 [compat]
 CFDomains = "0.1.6, 0.2"
@@ -28,6 +28,7 @@ ClimFluids = "0.1.2"
 ManagedLoops = "0.1.6"
 MutatingOrNot = "0.1.2"
 PackageExtensionCompat = "1"
+SHTnsSpheres = "0.2.7"
 julia = "1.8"
 
 [extras]

--- a/ext/SHTnsSpheres_Ext.jl
+++ b/ext/SHTnsSpheres_Ext.jl
@@ -20,13 +20,14 @@ end
 ## these "constructors" seem to help with type stability
 vector_spec(spheroidal, toroidal) = (; spheroidal, toroidal)
 vector_spat(ucolat, ulon) = (; ucolat, ulon)
-HPE_state(mass_spec, uv_spec) = (; mass_spec, uv_spec)
+HPE_state(mass_spec, masses_spec, uv_spec) = (; mass_spec, masses_spec, uv_spec)
 
 function initial_HPE_HV(model, nz, sph::SHTnsSphere, case)
     mass, ulon, ulat = CFHydrostatics.initial_HPE_HV_collocated(model, nz, sph.lon, sph.lat, model.gas, case)
     mass_spec = analysis_scalar!(void, mass, sph)
+    masses_spec = (air = analysis_scalar!(void, mass[:,:,:,1], sph), consvar = analysis_scalar!(void, mass[:,:,:,2], sph))
     uv_spec = analysis_vector!(void, vector_spat(-ulat, ulon), sph)
-    HPE_state(mass_spec, uv_spec)
+    HPE_state(mass_spec, masses_spec, uv_spec)
 end
 
 include("dynamics.jl")

--- a/ext/SHTnsSpheres_Ext.jl
+++ b/ext/SHTnsSpheres_Ext.jl
@@ -20,14 +20,23 @@ end
 ## these "constructors" seem to help with type stability
 vector_spec(spheroidal, toroidal) = (; spheroidal, toroidal)
 vector_spat(ucolat, ulon) = (; ucolat, ulon)
-HPE_state(mass_spec, masses_spec, uv_spec) = (; mass_spec, masses_spec, uv_spec)
+HPE_state(masses_spec, uv_spec) = (; masses_spec, uv_spec)
 
 function initial_HPE_HV(model, nz, sph::SHTnsSphere, case)
-    mass, ulon, ulat = CFHydrostatics.initial_HPE_HV_collocated(model, nz, sph.lon, sph.lat, model.gas, case)
-    mass_spec = analysis_scalar!(void, mass, sph)
-    masses_spec = (air = analysis_scalar!(void, mass[:,:,:,1], sph), consvar = analysis_scalar!(void, mass[:,:,:,2], sph))
+    masses, ulon, ulat = CFHydrostatics.initial_HPE_HV_collocated(
+        model,
+        nz,
+        sph.lon,
+        sph.lat,
+        model.gas,
+        case,
+    )
+    masses_spec = (
+        air = analysis_scalar!(void, masses.air, sph),
+        consvar = analysis_scalar!(void, masses.consvar, sph),
+    )
     uv_spec = analysis_vector!(void, vector_spat(-ulat, ulon), sph)
-    HPE_state(mass_spec, masses_spec, uv_spec)
+    HPE_state(masses_spec, uv_spec)
 end
 
 include("dynamics.jl")
@@ -37,8 +46,8 @@ HPE_tendencies!(dstate, scratch, model, _::SHTnsSphere, state, t) =
 
 include("diagnostics.jl")
 
-HPE_remap!(mgr, model, ::SHTnsSphere, new, #==# scratch, #==# now) =
-    remap!(mgr, model.vcoord, model.domain.layout, new, #==# scratch, #==# now)
+HPE_remap!(mgr, model, ::SHTnsSphere, new, scratch, now) = #==#
+    remap!(mgr, model.vcoord, model.domain.layout, new, scratch, now) #==#
 
 HPE_diagnostics(_, ::SHTnsSphere) = Diagnostics.diagnostics()
 

--- a/ext/diagnostics.jl
+++ b/ext/diagnostics.jl
@@ -26,9 +26,8 @@ diagnostics() = CookBook(;
     Omega,
     Phi_dot,
     # depend on vertical coordinate
-    mass,
     masses,
-    dmass,
+    dmasses,
     duv,
     # intermediate computations
     dstate,
@@ -46,10 +45,6 @@ diagnostics() = CookBook(;
 dstate(dstate_all) = dstate_all[1]
 dstate_all(model, state) = Dynamics.tendencies!(void, void, model, state, 0.0)
 
-mass(model, state) =
-    model.planet.radius^-2 *
-    synthesis_scalar!(void, copy(state.mass_spec), model.domain.layer)
-
 function masses(model, state)
     fac, sph = model.planet.radius^-2, model.domain.layer
     return (
@@ -57,8 +52,7 @@ function masses(model, state)
         consvar = synthesis_scalar!(void, fac*state.masses_spec.consvar, sph),
     )
 end
-
-dmass(model, dstate) = mass(model, dstate)
+dmasses(model, dstate) = masses(model, dstate)
 
 function uv(model, state)
     (; ucolat, ulon) = synthesis_vector!(void, map(copy, state.uv_spec), model.domain.layer)
@@ -69,18 +63,11 @@ end
 duv(model, dstate) = uv(model, dstate)
 
 ps_spec(model, state) = (model.planet.radius^-2) * sum(state.masses_spec.air; dims = 2)
-# ps_spec(model, state) =
-#    @views (model.planet.radius^-2) * sum(state.mass_spec[:, :, 1]; dims = 2)
+
 surface_pressure(model, ps_spec) =
     synthesis_scalar!(void, ps_spec[:, 1], model.domain.layer) .+ model.vcoord.ptop
 
-function conservative_variable(mass)
-    mass_air = @view mass[:, :, :, 1]
-    mass_consvar = @view mass[:, :, :, 2]
-    return @. mass_consvar / mass_air
-end
-
-# conservative_variable(masses) = @. masses.consvar / masses.air
+conservative_variable(masses) = @. masses.consvar / masses.air
 
 temperature(model, pressure, conservative_variable) =
     model.gas(:p, :consvar).temperature.(pressure, conservative_variable)
@@ -88,15 +75,15 @@ temperature(model, pressure, conservative_variable) =
 sound_speed(model, pressure, temperature) =
     model.gas(:p, :T).sound_speed.(pressure, temperature)
 
-function pressure(model, mass)
-    p = similar(mass[:, :, :, 1])
-    compute_pressure!(model.mgr, p, model, mass)
+function pressure(model, masses)
+    p = similar(masses.air)
+    compute_pressure!(model.mgr, p, model, masses.air)
     return p
 end
 
-function geopotential(model, mass, pressure)
+function geopotential(model, masses, pressure)
     Phi = similar(pressure, size(pressure) .+ (0, 0, 1))
-    compute_geopot!(nothing, Phi, model, mass, pressure)
+    compute_geopot!(nothing, Phi, model, masses, pressure)
     return Phi
 end
 
@@ -147,17 +134,17 @@ function gradPhi(model, uv, geopotential)
 end
 
 gradmass(model, state) =
-    synthesis_spheroidal!(void, state.mass_spec[:, :, 1], model.domain.layer)
+    synthesis_spheroidal!(void, state.masses_spec.air, model.domain.layer)
 
 Omega(vertical_velocities) = vertical_velocities.Omega
 Phi_dot(vertical_velocities) = vertical_velocities.Phi_dot
 
-function vertical_velocities(model, mass, dmass, ugradp, ugradPhi, pressure)
+function vertical_velocities(model, masses, dmasses, ugradp, ugradPhi, pressure)
     Omega, Phi_dot, dp = (similar(pressure) for _ = 1:3)
     compute_vertical_velocities(
         model.mgr, model,
         (Omega, Phi_dot, dp),
-        (mass, dmass, ugradp, ugradPhi, pressure),
+        (masses, dmasses, ugradp, ugradPhi, pressure),
     )
     return (; Omega, Phi_dot, dp)
 end

--- a/ext/dynamics.jl
+++ b/ext/dynamics.jl
@@ -15,7 +15,7 @@ using SHTnsSpheres:
 
 vector_spec(spheroidal, toroidal) = (; spheroidal, toroidal)
 vector_spat(ucolat, ulon) = (; ucolat, ulon)
-HPE_state(mass_spec, uv_spec) = (; mass_spec, uv_spec)
+HPE_state(mass_spec, masses_spec, uv_spec) = (; mass_spec, masses_spec, uv_spec)
 
 function tendencies!(dstate, scratch, model, state, t)
     # spectral fields are suffixed with _spec
@@ -23,8 +23,8 @@ function tendencies!(dstate, scratch, model, state, t)
     # vector, spatial = (ucolat, ulon)
     (; uv, flux, flux_spec, zeta, zeta_spec, qflux, qflux_spec) = scratch
     (; mass, p, geopot, consvar, B, exner, B_spec, exner_spec, grad_exner) = scratch
-    (; mass_spec, uv_spec) = state
-    dmass_spec, duv_spec = dstate.mass_spec, dstate.uv_spec
+    (; mass_spec, masses_spec, uv_spec) = state
+    dmass_spec, dmasses_spec, duv_spec = dstate.mass_spec, dstate.masses_spec, dstate.uv_spec
     mgr, sph, invrad2, fcov =
         model.mgr, model.domain.layer, model.planet.radius^-2, model.fcov
     mgr_spec = no_simd(mgr) # complex broadcasting + SIMD not supported
@@ -44,6 +44,10 @@ function tendencies!(dstate, scratch, model, state, t)
     flux_spec = analysis_vector!(flux_spec, flux, sph)
     dmass_spec = divergence!(mgr_spec[dmass_spec], flux_spec, sph)
 
+    dmasses_spec = (
+        air = (@. dmasses_spec.air = 0*masses_spec.air),
+        consvar = (@. dmasses_spec.consvar = 0*masses_spec.consvar)
+    )
     # curl-form momentum budget:
     #   ∂u/∂t = (f+ζ)v - θ∂π/∂x- ∂B/∂x
     #   ∂v/∂t = -(f+ζ)u - θ∂π/∂y - ∂B/∂y
@@ -91,7 +95,7 @@ function tendencies!(dstate, scratch, model, state, t)
         grad_exner,
     )
 
-    return HPE_state(dmass_spec, duv_spec), scratch
+    return HPE_state(dmass_spec, dmasses_spec, duv_spec), scratch
 end
 
 @loops function mass_flux!(_, fx, fy, factor, ux, uy, mass)

--- a/ext/dynamics.jl
+++ b/ext/dynamics.jl
@@ -16,7 +16,7 @@ using SHTnsSpheres:
 
 vector_spec(spheroidal, toroidal) = (; spheroidal, toroidal)
 vector_spat(ucolat, ulon) = (; ucolat, ulon)
-HPE_state(mass_spec, masses_spec, uv_spec) = (; mass_spec, masses_spec, uv_spec)
+HPE_state(masses_spec, uv_spec) = (; masses_spec, uv_spec)
 
 function tendencies!(dstate, scratch, model, state, t)
     # spectral fields are suffixed with _spec
@@ -25,9 +25,9 @@ function tendencies!(dstate, scratch, model, state, t)
     (; uv, zeta, zeta_spec, qflux, qflux_spec) = scratch
     (; p, geopot, consvar, B, exner, B_spec, exner_spec, grad_exner) = scratch
     (; masses, fluxes, fluxes_spec) = scratch
-    (; mass_spec, masses_spec, uv_spec) = state
-    dmass_spec, dmasses_spec, duv_spec =
-        dstate.mass_spec, dstate.masses_spec, dstate.uv_spec
+    (; masses_spec, uv_spec) = state
+    dmasses_spec, duv_spec =
+        dstate.masses_spec, dstate.uv_spec
     mgr, sph, invrad2, fcov =
         model.mgr, model.domain.layer, model.planet.radius^-2, model.fcov
     mgr_spec = no_simd(mgr) # complex broadcasting + SIMD not supported
@@ -113,9 +113,7 @@ function tendencies!(dstate, scratch, model, state, t)
         zeta_spec = B_spec,
     )
 
-    dmass_spec = @. mgr_spec[dmass_spec] = 0*mass_spec
-
-    return HPE_state(dmass_spec, dmasses_spec, duv_spec), scratch
+    return HPE_state(dmasses_spec, duv_spec), scratch
 end
 
 function hydrostatic_pressure!(p, model, air::Array{Float64,3})

--- a/src/CFHydrostatics.jl
+++ b/src/CFHydrostatics.jl
@@ -50,7 +50,7 @@ include("julia/remap_HPE.jl")
 include("julia/remap_collocated.jl")
 # include("julia/remap_voronoi.jl")
 
-include("julia/ext/SHTnsSpheres_Ext.jl") # only when developing (also Project.toml)
+# include("julia/ext/SHTnsSpheres_Ext.jl") # only when developing (also Project.toml)
 
 using PackageExtensionCompat
 function __init__()

--- a/src/CFHydrostatics.jl
+++ b/src/CFHydrostatics.jl
@@ -50,7 +50,7 @@ include("julia/remap_HPE.jl")
 include("julia/remap_collocated.jl")
 # include("julia/remap_voronoi.jl")
 
-# include("julia/ext/SHTnsSpheres_Ext.jl") # only when developing (also Project.toml)
+include("julia/ext/SHTnsSpheres_Ext.jl") # only when developing (also Project.toml)
 
 using PackageExtensionCompat
 function __init__()

--- a/src/julia/initialize.jl
+++ b/src/julia/initialize.jl
@@ -25,9 +25,9 @@ function initial_HPE_HV_collocated(model, nz, lon, lat, gas::SimpleFluid, case)
     radius, vcoord = model.planet.radius, model.vcoord
     consvar = gas(:p, :v).conservative_variable
     alloc(dims...) = similar(lon, size(lon)..., dims...)
-    mass, ulon, ulat = alloc(nz, 2), alloc(nz), alloc(nz)
+    masses, ulon, ulat = (air=alloc(nz), consvar=alloc(nz)), alloc(nz), alloc(nz)
 
-    for i in axes(mass, 1), j in axes(mass, 2), k = 1:nz
+    for i in axes(lon, 1), j in axes(lon, 2), k = 1:nz
         let lon = lon[i, j], lat = lat[i, j]
             ps, _ = case(lon, lat)
             p = pressure_level(2k - 1, ps, vcoord) # full level k
@@ -39,9 +39,9 @@ function initial_HPE_HV_collocated(model, nz, lon, lat, gas::SimpleFluid, case)
             Phi_lower, _, _ = case(lon, lat, p_lower)
             Phi_upper, _, _ = case(lon, lat, p_upper)
             v = (Phi_upper - Phi_lower) / mg # dPhi = -v . dp
-            mass[i, j, k, 1] = radius^2 * mg
-            mass[i, j, k, 2] = (radius^2 * mg) * consvar(p, v)
+            masses.air[i, j, k] = radius^2 * mg
+            masses.consvar[i, j, k] = (radius^2 * mg) * consvar(p, v)
         end
     end
-    return mass, ulon, ulat
+    return masses, ulon, ulat
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,7 +64,7 @@ end
 
 function scaling_pressure(choices)
     (; nlat, nz) = choices()
-    mass = randn(2nlat, nlat, nz, 2)
+    mass = randn(2nlat, nlat, nz)
     p = hydrostatic_pressure!(void, model(), mass)
     for vsize in (16,32)
         scaling("hydrostatic_pressure!", VectorizedCPU(vsize), 100) do mgr


### PR DESCRIPTION
Splits the prognostic field containing masses into to 3D fields instead of one 4D field. This leads to better-looking code. Also, the last dimension is always `nz` which works better with broadcast when using a multi-thread loop manager.